### PR TITLE
php - make www-data user to have the same uid/gid as the mounted volu…

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,6 @@
+DEBUG=yes
+
+UPDATE_UID_GID=yes
+
+# relative to docker-compose.yml
+SYLIUS_DIR=../path_to_folder_with_sylius installation

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+docker.env

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .idea/
-docker.env
+.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,8 @@ php:
         - elasticsearch
         - memcached
     mem_limit: 2000000000
+    env_file:
+        - docker.env
 
 elasticsearch:
     image: elasticsearch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 data:
     image: busybox
     volumes:
-        - ../../:/var/www/sylius
+        - ${SYLIUS_DIR}:/var/www/sylius
         - /vendor
         - ~/.ssh/id_rsa:/root/.ssh/id_rsa:ro
         - ~/.composer:/root/.composer
@@ -35,7 +35,7 @@ php:
         - memcached
     mem_limit: 2000000000
     env_file:
-        - docker.env
+        - .env
 
 elasticsearch:
     image: elasticsearch

--- a/docker.env.dist
+++ b/docker.env.dist
@@ -1,2 +1,0 @@
-DEBUG=yes
-UPDATE_UID_GID=yes

--- a/docker.env.dist
+++ b/docker.env.dist
@@ -1,0 +1,2 @@
+DEBUG=yes
+UPDATE_UID_GID=yes

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.0.2-fpm
+FROM php:7.1-fpm
 
 RUN \
   apt-get update && \

--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -30,4 +30,11 @@ RUN apt-get update && apt-get install -y \
 COPY php.ini        /usr/local/etc/php/conf.d/
 COPY default.conf    /usr/local/etc/php-fpm.d/www.conf
 
+ADD entrypoint-init.d /entrypoint-init.d
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 EXPOSE 9000
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+CMD ["php-fpm", "-F"]

--- a/php/docker-entrypoint.sh
+++ b/php/docker-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+set -e
+
+[ "${DEBUG}" = "yes" ] && set -x
+
+CMD=$(basename "$1")
+if [ "${CMD}" = 'php-fpm' ]; then
+    for SCRIPT in /entrypoint-init.d/*.sh; do
+        . "${SCRIPT}"
+    done
+fi
+
+exec "$@"

--- a/php/entrypoint-init.d/mapuid.sh
+++ b/php/entrypoint-init.d/mapuid.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+set -e
+
+[ "${DEBUG}" = "yes" ] && set -x
+
+# Make www-data user to have the same uid/gid as the mounted volume.
+# This is a work around for permission issues.
+
+if [[ "${UPDATE_UID_GID}" = "yes" ]]; then
+    DOCKER_UID=$(stat -c '%u' /var/www/sylius)
+    DOCKER_GID=$(stat -c '%g' /var/www/sylius)
+
+    echo "Docker: uid = ${DOCKER_UID}, gid = ${DOCKER_GID}"
+
+    usermod -u ${DOCKER_UID} www-data 2> /dev/null && {
+	    groupmod -g ${DOCKER_GID} www-data 2> /dev/null || usermod -a -G ${DOCKER_GID} www-data
+    }
+fi;


### PR DESCRIPTION
- Introduced an entry point for PHP container to update uid/gid of www-data user to be same as for the host user. The behavior can be enabled/disabled via environment variable.
- updated php version to 7.1
- introduced env variable to set path to the sylius installation folder