### PR TITLE
Add yarn to PHP container

### DIFF
--- a/php/Dockerfile
+++ b/php/Dockerfile
@@ -5,9 +5,12 @@ RUN \
   apt-get install -y \
   curl \
   wget \
-  git
+  git \
+  apt-transport-https
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+RUN curl -sL https://deb.nodesource.com/setup_6.x | bash -
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
 
 RUN apt-get update && apt-get install -y \
         libfreetype6-dev \
@@ -16,6 +19,8 @@ RUN apt-get update && apt-get install -y \
         libpng12-dev \
         libicu-dev \
         libicu52  \
+        nodejs \
+        yarn \
     && docker-php-ext-install iconv \
     && docker-php-ext-install exif \
     && docker-php-ext-install mbstring \


### PR DESCRIPTION
Adds yarn to PHP container so that host machine only depends on docker and nothing else.