### PR TITLE
Change www-data UID to current host-users UID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+docker-compose.local.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ ENV SYLIUS_VERSION dev-master
 ENV BASE_DIR /var/www
 ENV SYLIUS_DIR ${BASE_DIR}/sylius
 
+#Modify UID of www-data into UID of local user
+ARG AS_UID=33
+RUN usermod -u ${AS_UID} www-data
+
 # Operate as www-data in SYLIUS_DIR per default
 WORKDIR ${BASE_DIR}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
 FROM sylius/nginx-php-fpm:latest
 MAINTAINER Sylius Docker Team <docker@sylius.org>
 
+ARG AS_UID=33
+
 ENV SYLIUS_VERSION dev-master
 
 ENV BASE_DIR /var/www
 ENV SYLIUS_DIR ${BASE_DIR}/sylius
 
 #Modify UID of www-data into UID of local user
-ARG AS_UID=33
 RUN usermod -u ${AS_UID} www-data
 
 # Operate as www-data in SYLIUS_DIR per default

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ $(eval $(call defw,NAME,$(PROJECT)))
 UNAME_S := $(shell uname -s)
 
 ifneq ("$(wildcard $(DOCKER_COMPOSE_LOCAL))","")
-	DOCKER_COMPOSE_EXTRA_OPTIONS := -f $(DOCKER_COMPOSE_LOCAL)
+    DOCKER_COMPOSE_EXTRA_OPTIONS := -f $(DOCKER_COMPOSE_LOCAL)
 endif
 
 ifeq (Linux,$(UNAME_S))
-	$(eval $(call defw,AS_UID,$(shell id -u)))
+    $(eval $(call defw,AS_UID,$(shell id -u)))
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -4,14 +4,14 @@ $(eval $(call defw,DOCKER_COMPOSE_LOCAL,docker-compose.local.yml))
 $(eval $(call defw,PROJECT,sylius-standard))
 $(eval $(call defw,NAME,$(PROJECT)))
 
+UNAME_S := $(shell uname -s)
+
 ifneq ("$(wildcard $(DOCKER_COMPOSE_LOCAL))","")
 	DOCKER_COMPOSE_EXTRA_OPTIONS := -f $(DOCKER_COMPOSE_LOCAL)
 endif
 
-$(eval $(call defw,UNAME_S,$(shell uname -s)))
-
 ifeq (Linux,$(UNAME_S))
-   $(eval $(call defw,AS_UID,$(shell id -u)))
+	$(eval $(call defw,AS_UID,$(shell id -u)))
 endif
 
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,12 @@ ifneq ("$(wildcard $(DOCKER_COMPOSE_LOCAL))","")
 	DOCKER_COMPOSE_EXTRA_OPTIONS := -f $(DOCKER_COMPOSE_LOCAL)
 endif
 
+$(eval $(call defw,UNAME_S,$(shell uname -s)))
+
+ifeq (Linux,$(UNAME_S))
+   $(eval $(call defw,AS_UID,$(shell id -u)))
+endif
+
 
 .PHONY: build
 build:: ##@Docker Build the Sylius application image
@@ -28,6 +34,7 @@ up:: ##@Sylius Start the Sylius stack for development (using docker-compose)
 shell:: ##@Development Bring up a shell
 	docker exec \
 		-ti \
+        -u www-data \
 		${NAME}-app \
 		bash
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ You can control, customize and extend the behaviour of this environment with ``m
 
 # Development
 
+## Requirements
+
+Because ``docker-compose.yml`` uses Compose file format 2.1 at least **Docker version 1.12** ist required for this environment.
+
 ## Quickstart
 
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 
 services:
   sylius:
@@ -6,7 +6,7 @@ services:
     build:
         context: .
         args:
-            - AS_UID=${AS_UID}
+          - AS_UID=${AS_UID:-33}
     environment:
       - SYLIUS_DATABASE_HOST=mysql
       - SYLIUS_DATABASE_USER=sylius

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,10 @@ version: '2'
 services:
   sylius:
     container_name: ${NAME}-app
-    build: .
+    build:
+        context: .
+        args:
+            - AS_UID=${AS_UID}
     environment:
       - SYLIUS_DATABASE_HOST=mysql
       - SYLIUS_DATABASE_USER=sylius


### PR DESCRIPTION
In order to read and write as the same user into mounted volumes the UID of a user inside the container must be the same as on the host.

This change enables to read and write into mounted volumes on linux.

@adepretis Thanks for your snippets.